### PR TITLE
Add support for collapsable/details sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,17 @@ ______
 ```
 ### Escaping characters
 Control characters can be escaped by preceding them with a backslash `\`
+
+### Collapsable sections
+Collapsable sections are supported and follow the html for a `details` section.
+```
+<details>
+<summary>Summary text</summary>
+Text
+</details>
+```
+Will render as 
+<details>
+<summary>Summary text</summary>
+Text
+</details>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub fn lex(source: &str) -> Vec<Token>{
     tokens
 }
 
-pub fn parse(tokens: Vec<Token>) -> String {
+pub fn parse(tokens: &Vec<Token>) -> String {
     let mut html = String::new();
     let mut in_ordered_list = false;
     let mut in_unordered_list = false;
@@ -245,6 +245,10 @@ pub fn parse(tokens: Vec<Token>) -> String {
                     (None, None) => html.push_str(format!("<a href=\"{link}\">{link}</a>", link=l).as_str()),
                 }
             },
+            Token::Detail(summary, inner_tokens) => {
+                let inner_html = parse(inner_tokens);
+                html.push_str(format!("<details>\n<summary>{sum}</summary>\n{in_html}\n</details>", sum=sanitize(summary), in_html=inner_html).as_str());
+            }
             _ => {},
         }
     }
@@ -261,7 +265,7 @@ pub fn parse(tokens: Vec<Token>) -> String {
 }
 
 pub fn render(source: &str) -> String {
-    parse(lex(source))
+    parse(&lex(source))
 }
 
 pub fn sanitize(source: &String) -> String {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -61,11 +61,24 @@ fn test_moderate_render(){
         ("Testing an inline link to a header id [Link title](#some-header)",
         "<p>Testing an inline link to a header id <a href=\"#some-header\">Link title</a></p>"
         ),
+        ("Testing some details <details>\n<summary markdown=\"span\">Summary text goes here</summary>\nSome text goes here\n</details>",
+        "<p>Testing some details <details>\n<summary>Summary text goes here</summary>\n\n<p>Some text goes here\n</p>\n</details></p>"
+        ),
+        ("Testing some nested details <details>\n<summary markdown=\"span\">Outer summary</summary>\nOuter text<details>\n<summary markdown=\"span\">Inner Summary</summary>\nInner text\n</details>\n</details>",
+        "<p>Testing some nested details <details>\n<summary>Outer summary</summary>\n\n<p>Outer text<details>\n<summary>Inner Summary</summary>\n\n<p>Inner text\n</p>\n</details>\n</p>\n</details></p>"
+        ),
     ]);
 
     for test in tests.iter(){
         let html = render(test.0);
-        // println!("lex: {:?}", lex(test.0));
+        if html != test.1 {
+            println!("Test failing\n{:?}\n{:?}", html, test.1);
+            for (c1, c2) in test.1.chars().zip(html.chars()) {
+                if c1 != c2 {
+                    println!("Difference in {:?} {:?}", c1, c2);
+                }
+            }
+        }
         assert_eq!(html, test.1);
     }
 }


### PR DESCRIPTION
Support for nested collapsables is included and a basic double nest test has been added.
Also along for the ride is a minor improvement to the testing loop to expose differences in strings.