### PR TITLE
Add support for html tables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,13 @@ pub fn lex(source: &str) -> Vec<Token>{
                     Err(e) => push_str(&mut tokens, e.content),
                 }
             },
+            '|' => {
+                let token = lex_pipes(&mut char_iter);
+                match token {
+                    Ok(t) => tokens.push(t),
+                    Err(e) => push_str(&mut tokens, e.content),
+                }
+            },
             '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '0' => {
                 let token = lex_numbers(&mut char_iter);
                 match token {
@@ -248,7 +255,23 @@ pub fn parse(tokens: &Vec<Token>) -> String {
             Token::Detail(summary, inner_tokens) => {
                 let inner_html = parse(inner_tokens);
                 html.push_str(format!("<details>\n<summary>{sum}</summary>\n{in_html}\n</details>", sum=sanitize(summary), in_html=inner_html).as_str());
-            }
+            },
+            Token::Table(headings, rows) => {
+                //Assert headings.len() == rows.width()
+                html.push_str("<table class=\"table table-bordered\">\n\t<thead>\n\t<tr>\n");
+                for h in headings.into_iter() {
+                    html.push_str(format!("\t\t<th style=\"text-align: {align}\">{heading}</th>", heading=h.1, align=h.0).as_str());
+                }
+                html.push_str("\t</tr>\n\t</thead>\n\t<tbody>");
+                for row in rows.iter(){
+                    html.push_str("\n\t<tr>");
+                    for elem in row.iter(){
+                        html.push_str(format!("\n\t\t<td style=\"text-align: {align}\">{row_text}</td>", align=elem.0, row_text=elem.1).as_str());
+                    }
+                    html.push_str("\n\t</tr>");
+                }
+                html.push_str("\n\t</tbody>\n</table>");
+            },
             _ => {},
         }
     }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -83,6 +83,28 @@ fn test_moderate_render(){
     }
 }
 
+#[test]
+fn test_table_render() {
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("| Syntax      | Description | Test Text     |\n| :---        |    :----:   |          ---: |\n| Header      | Title       | Here's this   |\n| Paragraph   | Text        | And more      |", 
+        "<table class=\"table table-bordered\">\n\t<thead>\n\t<tr>\n\t\t<th style=\"text-align: left\">Syntax</th>\t\t<th style=\"text-align: center\">Description</th>\t\t<th style=\"text-align: right\">Test Text</th>\t</tr>\n\t</thead>\n\t<tbody>\n\t<tr>\n\t\t<td style=\"text-align: left\">Header</td>\n\t\t<td style=\"text-align: center\">Title</td>\n\t\t<td style=\"text-align: right\">Here's this</td>\n\t</tr>\n\t<tr>\n\t\t<td style=\"text-align: left\">Paragraph</td>\n\t\t<td style=\"text-align: center\">Text</td>\n\t\t<td style=\"text-align: right\">And more</td>\n\t</tr>\n\t</tbody>\n</table>"),
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        if html != test.1 {
+            println!("Test failing\n{:?}\n{:?}", html, test.1);
+            for (c1, c2) in test.1.chars().zip(html.chars()) {
+                if c1 != c2 {
+                    println!("Difference in {:?} {:?}", c1, c2);
+                }
+            }
+        }
+        assert_eq!(html, test.1);
+    }
+}
+
 // use std::fs;
 
 #[test]


### PR DESCRIPTION
This PR adds support for html tables as discussed here
https://www.markdownguide.org/extended-syntax/
The example table is used as a test case.
Alignment does require memory copies which could be removed in the future

Any invalid alignment is defaulted to left align. Easy to change in the future, but probably acceptable.