### PR TITLE
Validate urls and expand character replacement

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -17,7 +17,7 @@ pub enum Token {
     Code(String),
     CodeBlock(String, String),
     BlockQuote(u8, String),
-    Image(String, String), // (Link, title)
+    Image(String, Option<String>), // (Link, title)
     Link(String, Option<String>, Option<String>), //(link, title, hover text)
     Detail(String, Vec<Token>),
     Table(Vec<(Alignment, String)>, Vec<Vec<(Alignment, Vec<Token>)>>)
@@ -240,7 +240,7 @@ pub(crate) fn lex_images(char_iter: &mut std::iter::Peekable<std::str::Chars>) -
     let link_result = lex_links(char_iter);
     match link_result {
         Err(e) => return Err(e),
-        Ok(Token::Link(link, title, _)) => return Ok(Token::Image(link, title.unwrap_or("".to_string()))),
+        Ok(Token::Link(link, title, _)) => return Ok(Token::Image(link, title)),
         _ => return Err(ParseError{content: "Non link token returned from lex_links".to_string()})
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -109,6 +109,23 @@ fn test_table_render() {
     }
 }
 
+#[test]
+fn test_images(){
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("![Alt text](foo.jpeg)", "<img src=\"foo.jpeg\" alt=\"Alt text\">"),
+        ("![Alt text]()", "<img src=\"data:,\" alt=\"Alt text\">"),
+        ("![Alt text](   )", "<img src=\"data:,\" alt=\"Alt text\">"),
+        ("![Alt text](https://example.com/my/cool/image.png)", "<img src=\"https://example.com/my/cool/image.png\" alt=\"Alt text\">"),
+        ("![Red dot](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==)", "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\" alt=\"Red dot\">"),
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        assert_eq!(html, test.1);
+    }
+}
+
 // use std::fs;
 
 #[test]

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -60,6 +60,10 @@ fn test_lex() {
         ])
     ]);
     tests.extend(vec![
+        ("![alt](https://example.com/foo.jpeg)", vec![Token::Image("https://example.com/foo.jpeg".to_string(), Some("alt".to_string()))]),
+        ("![alt]()", vec![Token::Image("".to_string(), Some("alt".to_string()))]),
+    ]);
+    tests.extend(vec![
         ("¯\\\\\\_(ツ)\\_/¯", vec![Token::Plaintext("¯\\_(ツ)_/¯".to_string())]),
         ("\\_test\\_", vec![Token::Plaintext("_test_".to_string())]),
         ("\\*escaping\\_", vec![Token::Plaintext("*escaping_".to_string())]),

--- a/tests/sanitation.rs
+++ b/tests/sanitation.rs
@@ -1,4 +1,4 @@
-use mini_markdown::sanitize;
+use mini_markdown::sanitize_display_text;
 
 #[test]
 fn test_simple_tag_removal() {
@@ -13,7 +13,37 @@ fn test_simple_tag_removal() {
     ]);
 
     for test in tests.iter_mut(){
-        let untagged = sanitize(&mut test.0);
+        let untagged = sanitize_display_text(&mut test.0);
         assert_eq!(untagged, test.1);
+    }
+}
+
+use mini_markdown::render;
+#[test]
+fn test_image_xss(){
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("![Alt text](foo.jpeg)", "<img src=\"foo.jpeg\" alt=\"Alt text\">"),
+        ("![Alt text]()", "<img src=\"data:,\" alt=\"Alt text\">"),
+        ("![Alt text](   )", "<img src=\"data:,\" alt=\"Alt text\">"),
+        ("![Alt text](javascript:alert(0))", "<img src=\"data:,\" alt=\"Alt text\">"),
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        assert_eq!(html, test.1);
+    }
+}
+
+#[test]
+fn test_link_xss() {
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("[text](javascript:alert(0))", "<a href=\"\">text</a>"),
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        assert_eq!(html, test.1);
     }
 }


### PR DESCRIPTION
This PR adds a few things
* Validate urls before using
* Character replace only on display text
* Expand scope of characters replaced
* Use `data:,` for missing/broken urls to avoid render errors
* Add tests to cover expected behavior