### PR TITLE
Add support for task lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 
 /target
 #Cargo.lock
+
+# MacOS
+.DS_Store

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -128,6 +128,40 @@ fn test_images(){
     }
 }
 
+#[test]
+fn test_tasklists(){
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("- [ ] One task",
+        "<ul class=\"contains-task-list\"><li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One task</li></ul>"),
+        ("- [x] One other task",
+        "<ul class=\"contains-task-list\"><li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\">One other task</li></ul>"),
+        ("- [x] One other task\n- [ ] One task\n- [ ] One last task",
+        "<ul class=\"contains-task-list\"><li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\">One other task</li></ul>\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One task</li></ul>\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One last task</li></ul>"),
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        assert_eq!(html, test.1);
+    }
+}
+
+#[test]
+fn test_lists(){
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("* One entry",
+        "<ul><li>One entry</li></ul>"),
+        ("1. One entry",
+        "<ol><li>One entry</li></ol>"),
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        assert_eq!(html, test.1);
+    }
+}
+
 // use std::fs;
 
 #[test]

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -1,5 +1,5 @@
 use mini_markdown::lex;
-use mini_markdown::lexer::Token;
+use mini_markdown::lexer::{Token, TaskBox};
 
 #[test]
 fn test_lex() {
@@ -68,6 +68,15 @@ fn test_lex() {
         ("\\_test\\_", vec![Token::Plaintext("_test_".to_string())]),
         ("\\*escaping\\_", vec![Token::Plaintext("*escaping_".to_string())]),
         ("\\>controls\\<", vec![Token::Plaintext(">controls<".to_string())])
+    ]);
+    tests.extend(vec![
+        ("---", vec![Token::HorizontalRule]),
+        ("-----", vec![Token::HorizontalRule]),
+        ("--", vec![Token::Plaintext("--".to_string())]),
+        ("- [ ] Unchecked box", vec![Token::TaskListItem(TaskBox::Unchecked, "Unchecked box".to_string())]),
+        ("- [x] Checked box", vec![Token::TaskListItem(TaskBox::Checked, "Checked box".to_string())]),
+        ("- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "Also a checked box".to_string())]),
+        ("- [X]Not a checked box", vec![Token::Plaintext("- [X]Not a checked box".to_string())]),
     ]);
     for test in tests.iter(){
         let tokens = lex(test.0);


### PR DESCRIPTION
This PR adds support for task lists and resolves an issue where lists were not terminated if they were the final token being parsed.
Also included is an ignore for the macos .DS_Store file