### PR TITLE
Cleanup and code visibility reduction

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -285,13 +285,14 @@ pub(crate) fn lex_links(char_iter: &mut std::iter::Peekable<std::str::Chars>) ->
 pub(crate) fn lex_side_carrot(char_iter: &mut std::iter::Peekable<std::str::Chars>) -> Result<Token, ParseError> {
     match char_iter.peek() {
         Some(&'<') => {
+            char_iter.next();
             let s = consume_while_case_holds(char_iter, &|c| c != &'>');
             match char_iter.peek(){
-                Some(&'>') if s != "<details" => {
+                Some(&'>') if s != "details" => {
                     char_iter.next();
                     return Ok(Token::Link(s, None, None))
                 },
-                Some(&'>') if s == "<details" => {
+                Some(&'>') if s == "details" => {
                     char_iter.next();
                     if !char_iter.next_if_eq(&'\n').is_some(){
                         return Err(ParseError{content: s});

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -56,10 +56,10 @@ fn test_moderate_render(){
         "<p>Don&apos;t -&gt; quote\n</p><blockquote>Do Quote\n</blockquote><p>Don&apos;t quote this either</p>"
         ),
         ("Testing an inline link [Link title](http://google.com)",
-        "<p>Testing an inline link <a href=\"http://google.com\">Link title</a></p>"
+        "<p>Testing an inline link <a href=\"http://google.com\" referrerpolicy=\"no-referrer\">Link title</a></p>"
         ),
         ("Testing an inline link to a header id [Link title](#some-header)",
-        "<p>Testing an inline link to a header id <a href=\"#some-header\">Link title</a></p>"
+        "<p>Testing an inline link to a header id <a href=\"#some-header\" referrerpolicy=\"no-referrer\">Link title</a></p>"
         ),
         ("Testing some details <details>\n<summary markdown=\"span\">Summary text goes here</summary>\nSome text goes here\n</details>",
         "<p>Testing some details <details>\n<summary>Summary text goes here</summary>\n\n<p>Some text goes here\n</p>\n</details></p>"
@@ -113,11 +113,11 @@ fn test_table_render() {
 fn test_images(){
     let mut tests = Vec::new();
     tests.extend(vec![
-        ("![Alt text](foo.jpeg)", "<img src=\"foo.jpeg\" alt=\"Alt text\">"),
+        ("![Alt text](foo.jpeg)", "<img src=\"foo.jpeg\" alt=\"Alt text\" referrerpolicy=\"no-referrer\">"),
         ("![Alt text]()", "<img src=\"data:,\" alt=\"Alt text\">"),
         ("![Alt text](   )", "<img src=\"data:,\" alt=\"Alt text\">"),
-        ("![Alt text](https://example.com/my/cool/image.png)", "<img src=\"https://example.com/my/cool/image.png\" alt=\"Alt text\">"),
-        ("![Red dot](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==)", "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\" alt=\"Red dot\">"),
+        ("![Alt text](https://example.com/my/cool/image.png)", "<img src=\"https://example.com/my/cool/image.png\" alt=\"Alt text\" referrerpolicy=\"no-referrer\">"),
+        ("![Red dot](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==)", "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\" alt=\"Red dot\" referrerpolicy=\"no-referrer\">"),
         ("![Red dot](data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==)", "<img src=\"data:,\" alt=\"Red dot\">"),
 
     ]);
@@ -137,7 +137,7 @@ fn test_tasklists(){
         ("- [x] One other task",
         "<ul class=\"contains-task-list\"><li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\">One other task</li></ul>"),
         ("- [x] One other task\n- [ ] One task\n- [ ] One last task",
-        "<ul class=\"contains-task-list\"><li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\">One other task</li></ul>\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One task</li></ul>\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One last task</li></ul>"),
+        "<ul class=\"contains-task-list\"><li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\">One other task</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One task</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\">One last task</li></ul>"),
     ]);
 
     for test in tests.iter(){

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -62,6 +62,7 @@ fn test_lex() {
     tests.extend(vec![
         ("![alt](https://example.com/foo.jpeg)", vec![Token::Image("https://example.com/foo.jpeg".to_string(), Some("alt".to_string()))]),
         ("![alt]()", vec![Token::Image("".to_string(), Some("alt".to_string()))]),
+        ("Some test text [^1]", vec![Token::Plaintext("Some test text [^1]".to_string())]),
     ]);
     tests.extend(vec![
         ("¯\\\\\\_(ツ)\\_/¯", vec![Token::Plaintext("¯\\_(ツ)_/¯".to_string())]),
@@ -77,6 +78,7 @@ fn test_lex() {
         ("- [x] Checked box", vec![Token::TaskListItem(TaskBox::Checked, "Checked box".to_string())]),
         ("- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "Also a checked box".to_string())]),
         ("- [X]Not a checked box", vec![Token::Plaintext("- [X]Not a checked box".to_string())]),
+        ("- [X] A checked box\n- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "A checked box".to_string()), Token::Newline, Token::TaskListItem(TaskBox::Checked, "Also a checked box".to_string())]),
     ]);
     for test in tests.iter(){
         let tokens = lex(test.0);


### PR DESCRIPTION
This PR
* Removes public visibility of sanitize_display_text.
* Fix quick links to not propagate leading <
* Rejects urls which contain whitespace
* Add no ref attribute for links and images. To be made configurable later
* Cleans up logic around closing tags at the start of the parser