### PR TITLE
Merge the quote level handling into the multi-liners match

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,19 +146,14 @@ pub fn parse(tokens: &Vec<Token>) -> String {
                 in_task_list = false;
                 html.push_str(format!("</ul>").as_str())
             },
-            _ => {}
-        }
-        if quote_level > 0 {
-            match token {
-                Token::BlockQuote(_l, _s) => {},
-                Token::Newline => {},
-                _ => {
-                    for _i in 0..quote_level {
+            Token::BlockQuote(_, _) | Token::Newline if quote_level > 0 => {},
+            _ if quote_level > 0 => {
+                for _i in 0..quote_level {
                         html.push_str(format!("</blockquote>").as_str());
                         quote_level-=1;
                     }
-                }
-            }
+            },
+            _ => {}
         }
 
         // Add content


### PR DESCRIPTION
Minor cleanup to fold quote level handling into the single match case for multi-liners