### PR TITLE
Support big footnotes

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -191,6 +191,8 @@ fn test_references(){
     tests.extend(vec![
         ("Here's some text. And a ref [^1]\n [^1]: Reference text",
         "<p>Here's some text. And a ref <sup id=\"fnref:1\" role=\"doc-noteref\"><a href=\"#fn:1\" class=\"footnote\" rel=\"footnote\">1</a></sup></p>\n<div class=\"footnotes\" role=\"doc-endnotes\">\n\t<ol>\n\t\t<li id=\"fn:1\" role=\"doc-endnote\">\t\t\t<p>Reference text<a href=\"#fnref:1\" class=\"reversefootnote\" role=\"doc-backlink\">↩</a></p>\t\t</li>\t</ol>\n</div>\n"),
+        ("Here's some text. And a ref [^1]\n [^1]: Reference text\n\twith multiple\n    lines\n  to ensure those work",
+        "<p>Here's some text. And a ref <sup id=\"fnref:1\" role=\"doc-noteref\"><a href=\"#fn:1\" class=\"footnote\" rel=\"footnote\">1</a></sup></p>\n<div class=\"footnotes\" role=\"doc-endnotes\">\n\t<ol>\n\t\t<li id=\"fn:1\" role=\"doc-endnote\">\t\t\t<p>Reference text\nwith multiple\nlines\nto ensure those work<a href=\"#fnref:1\" class=\"reversefootnote\" role=\"doc-backlink\">↩</a></p>\t\t</li>\t</ol>\n</div>\n"),
     ]);
 
     for test in tests.iter(){

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -104,3 +104,20 @@ fn test_blockquote_lex() {
         assert_eq!(&tokens[..], &test.1[..]);
     }
 }
+
+#[test]
+fn test_footnote_lex() {
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("[^1]: Footnote #1", vec![Token::Footnote("1".to_string(), "Footnote #1".to_string())]),
+        ("[^1]: Footnote #1\n  with a second line", vec![Token::Footnote("1".to_string(), "Footnote #1\nwith a second line".to_string())]),
+        ("[^1]: Footnote #1\n\twith a second line", vec![Token::Footnote("1".to_string(), "Footnote #1\nwith a second line".to_string())]),
+        ("[^1]: Footnote #1\n    with a second line", vec![Token::Footnote("1".to_string(), "Footnote #1\nwith a second line".to_string())]),
+        ("[^1]: Footnote #1\n    with a second line\n\tand a third line", vec![Token::Footnote("1".to_string(), "Footnote #1\nwith a second line\nand a third line".to_string())]),
+    ]);
+
+    for test in tests.iter(){
+        let tokens = lex(test.0);
+        assert_eq!(&tokens[..], &test.1[..]);
+    }
+}


### PR DESCRIPTION
Add support for big multi line footnotes. Support is limited at the moment to lines which are indented with 2 or 4 spaces or a tab `\t` character. The indents are intermixable and must follow a newline `\n`.