### PR TITLE
Fix missing !'s in plaintext

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -253,7 +253,7 @@ pub(crate) fn lex_images(char_iter: &mut std::iter::Peekable<std::str::Chars>) -
     char_iter.next();
     let link_result = lex_links(char_iter);
     match link_result {
-        Err(e) => return Err(e),
+        Err(e) => return Err(ParseError{content: "!".to_owned()+&e.content}),
         Ok(Token::Link(link, title, _)) => return Ok(Token::Image(link, title)),
         _ => return Err(ParseError{content: "Non link token returned from lex_links".to_string()})
     }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -14,6 +14,8 @@ fn test_simple_render() {
         ("###### Heading level 6", "<h6 id=\"heading-level-6\">Heading level 6</h6>\n"),
         ("####### Invalid Heading level 7", "<h6 id=\"invalid-heading-level-7\">Invalid Heading level 7</h6>\n"),
         ("Some text _with italics_ in the same paragraph\n", "<p>Some text <em>with italics</em> in the same paragraph\n</p>\n"),
+        ("Some text! With exclamations!", "<p>Some text! With exclamations!</p>\n"),
+
     ]);
 
     for test in tests.iter(){


### PR DESCRIPTION
Plaintext bangs were being consumed as if they were the start of an image and not returned in the error case.
The result was that they were being dropped from plaintext blocks