### PR TITLE
Redo detail parsing

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -428,20 +428,11 @@ fn parse_details(char_iter: &mut std::iter::Peekable<std::str::Chars>) -> Result
     if !summary_line.starts_with("<summary") || !summary_line.ends_with("</summary>") {
         return Err(ParseError{content: summary_line});
     }
-    summary_line = summary_line.strip_prefix("<summary").unwrap_or("").to_string();
+    summary_line = summary_line.strip_prefix("<summary>").unwrap_or("").to_string();
     summary_line = summary_line.strip_suffix("</summary>").unwrap_or("").to_string();
-    match summary_line.chars().nth(0){
-        Some('>') => {summary_line.clear()},
-        Some(' ') => {
-            if !summary_line.starts_with(" markdown=\"span\">"){
-                return Err(ParseError{content:format!("{}{}{}","<summary" ,summary_line, "</summary>")})
-            }
-            summary_line = summary_line.strip_prefix(" markdown=\"span\">").unwrap_or("").to_string();
-        },
-        Some(c) => {
-            return Err(ParseError{content:format!("{}{}{}{}","<summary", c,summary_line, "</summary>")})
-        },
-        None => return Err(ParseError{content:format!("{}{}{}","<summary" ,summary_line, "</summary>")})
+    match summary_line.len() {
+        0 => {return Err(ParseError{content:format!("{}","<summary></summary>")})},
+        _ => {},
     }
     let mut remaining_text = consume_until_tail_is(char_iter, "</details>");
     if remaining_text.contains("<details>") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub fn parse(tokens: &[Token]) -> String {
             },
             Token::BlockQuote(l, t) => {
                 if in_paragraph {
-                    html.push_str(format!("</p>").as_str());
+                    html.push_str("</p>");
                     in_paragraph = false;
                 }
                 match quote_level {
@@ -307,6 +307,10 @@ pub fn parse(tokens: &[Token]) -> String {
                 }
             },
             Token::Detail(summary, inner_tokens) => {
+                if in_paragraph {
+                    html.push_str("</p>\n");
+                    in_paragraph = false;
+                }
                 let inner_html = parse(inner_tokens);
                 html.push_str(format!("<details>\n<summary>{sum}</summary>\n{in_html}\n</details>", sum=sanitize_display_text(summary), in_html=inner_html).as_str());
             },

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -63,18 +63,18 @@ fn test_moderate_render(){
         ("Testing an inline link to a header id [Link title](#some-header)",
         "<p>Testing an inline link to a header id <a href=\"#some-header\" referrerpolicy=\"no-referrer\">Link title</a></p>\n"
         ),
-        ("Testing some details <details>\n<summary markdown=\"span\">Summary text goes here</summary>\nSome text goes here\n</details>",
-        "<p>Testing some details <details>\n<summary>Summary text goes here</summary>\n<p>Some text goes here\n</p>\n\n</details></p>\n"
+        ("Testing some details\n<details>\n<summary>Summary text goes here</summary>\nSome text goes here\n</details>",
+        "<p>Testing some details\n</p>\n<details>\n<summary>Summary text goes here</summary>\n<p>Some text goes here\n</p>\n\n</details>"
         ),
-        ("Testing some nested details <details>\n<summary markdown=\"span\">Outer summary</summary>\nOuter text<details>\n<summary markdown=\"span\">Inner Summary</summary>\nInner text\n</details>\n</details>",
-        "<p>Testing some nested details <details>\n<summary>Outer summary</summary>\n<p>Outer text<details>\n<summary>Inner Summary</summary>\n<p>Inner text\n</p>\n\n</details></p>\n\n</details></p>\n"
+        ("Testing some nested details <details>\n<summary>Outer summary</summary>\nOuter text<details>\n<summary>Inner Summary</summary>\nInner text\n</details>\n</details>",
+        "<p>Testing some nested details </p>\n<details>\n<summary>Outer summary</summary>\n<p>Outer text</p>\n<details>\n<summary>Inner Summary</summary>\n<p>Inner text\n</p>\n\n</details>\n</details>"
         ),
     ]);
 
     for test in tests.iter(){
         let html = render(test.0);
         if html != test.1 {
-            println!("Test failing\n{:?}\n{:?}", html, test.1);
+            println!("Test failing:\nGot:{:?}\nExpected:{:?}", html, test.1);
             println!("{:?}", lex(test.0));
             for (c1, c2) in test.1.chars().zip(html.chars()) {
                 if c1 != c2 {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -237,3 +237,22 @@ fn test_links(){
         assert_eq!(html, test.1);
     }
 }
+
+#[test]
+fn test_details(){
+    let mut tests = Vec::new();
+    tests.extend(vec![
+        ("<details>\n<summary>Summary</summary>\n\n```\nFoo\n```\n</details>",
+         "<details>\n<summary>Summary</summary>\n\n<div class=\"language-plaintext highlighter-rouge\"><div class=\"highlight\"><pre class=\"highlight\"><code>Foo\n</code></pre></div></div>\n</details>"),
+         ("<details>\n<summary>Summary but with spaces</summary>\n\n```\nFoo\n```\n</details>",
+         "<details>\n<summary>Summary but with spaces</summary>\n\n<div class=\"language-plaintext highlighter-rouge\"><div class=\"highlight\"><pre class=\"highlight\"><code>Foo\n</code></pre></div></div>\n</details>"),
+        ("Here's some lead text\n <details>\n<summary>Summary</summary>\n\n```\nFoo\n```\n</details>",
+         "<p>Here&apos;s some lead text\n </p>\n<details>\n<summary>Summary</summary>\n\n<div class=\"language-plaintext highlighter-rouge\"><div class=\"highlight\"><pre class=\"highlight\"><code>Foo\n</code></pre></div></div>\n</details>")
+    ]);
+
+    for test in tests.iter(){
+        let html = render(test.0);
+        assert_eq!(html, test.1);
+    }
+    
+}


### PR DESCRIPTION
This should help to resolve details sections not being rendered correctly.
Paragraphs and now correctly ended before details sections
Tests added