### PR TITLE
Convert ParseError from Strings to strs

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -76,4 +76,12 @@ impl <'a> MiniIter<'a> {
         }
         self.the_str.get(start_index..self.index)
     }
+
+    pub fn get_index(&self) -> usize{
+        self.index
+    }
+
+    pub fn get_substring_from(&self, start: usize) -> Option<&'a str> {
+        self.the_str.get(start..self.index)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,12 +112,12 @@ pub fn lex(source: &str) -> Vec<Token>{
                 char_iter.next();
                 if char_iter.peek().is_some(){
                     let c = char_iter.next().unwrap();
-                    push_str(&mut tokens, c.to_string());
+                    push_str(&mut tokens, c);
                 }
             }
             _ => {
                 let c = char_iter.next().unwrap();
-                push_str(&mut tokens, c.to_string());
+                push_str(&mut tokens, c);
             },
         }
     }


### PR DESCRIPTION
Add functions to the iter to allow for substring referencing and use those to populate ParseErrors