### PR TITLE
Revert code from &str to String usage interally

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,12 +197,10 @@ pub fn parse(tokens: &[Token]) -> String {
                 }
             },
             Token::Header(l, t, lbl) => {
-                let mut id;
-                match lbl {
-                    Some(_t) => id = lbl.unwrap().to_string(),
-                    None => id = t.to_string(),
+                let id = match lbl {
+                    Some(text) => text.to_ascii_lowercase(),
+                    None => t.to_ascii_lowercase(),
                 };
-                id.make_ascii_lowercase();
                 html.push_str(format!("<h{level} id=\"{id}\">{text}</h{level}>\n", 
                     level=l, 
                     text=sanitize_display_text(t), 
@@ -251,7 +249,7 @@ pub fn parse(tokens: &[Token]) -> String {
                 html.push_str(format!("<code>{}</code>", sanitize_display_text(t)).as_str())},
             Token::CodeBlock(t, lang) => {
                 html.push_str("<pre>");
-                match *lang {
+                match lang.as_str() {
                     "" => html.push_str(format!("<code>{}</code>", sanitize_display_text(t)).as_str()),
                     _ => html.push_str(format!(
                         "<div class=\"language-{} highlighter-rouge\"><div class=\"highlight\"><pre class=\"highlight\"><code>{}</code></div></div>",

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -5,66 +5,66 @@ use mini_markdown::lexer::{Token, TaskBox};
 fn test_lex() {
     let mut tests = Vec::new();
     tests.extend(vec![
-        ("# Heading level 1", vec![Token::Header(1, "Heading level 1", None)]),
-        ("## Heading level 2", vec![Token::Header(2, "Heading level 2", None)]),
-        ("### Heading level 3", vec![Token::Header(3, "Heading level 3", None)]),
-        ("#### Heading level 4", vec![Token::Header(4, "Heading level 4", None)]),
-        ("##### Heading level 5", vec![Token::Header(5, "Heading level 5", None)]),
-        ("###### Heading level 6", vec![Token::Header(6, "Heading level 6", None)]),
-        ("####### Invalid Heading level 7", vec![Token::Header(6, "Invalid Heading level 7", None)]), 
+        ("# Heading level 1", vec![Token::Header(1, "Heading level 1".to_string(), None)]),
+        ("## Heading level 2", vec![Token::Header(2, "Heading level 2".to_string(), None)]),
+        ("### Heading level 3", vec![Token::Header(3, "Heading level 3".to_string(), None)]),
+        ("#### Heading level 4", vec![Token::Header(4, "Heading level 4".to_string(), None)]),
+        ("##### Heading level 5", vec![Token::Header(5, "Heading level 5".to_string(), None)]),
+        ("###### Heading level 6", vec![Token::Header(6, "Heading level 6".to_string(), None)]),
+        ("####### Invalid Heading level 7", vec![Token::Header(6, "Invalid Heading level 7".to_string(), None)]), 
     ]);
     tests.extend(vec![
-        ("# Heading level 1 {#Test label}", vec![Token::Header(1, "Heading level 1", Some("Test label"))]),
-        ("## Heading level 2 {#Test label}", vec![Token::Header(2, "Heading level 2", Some("Test label"))]),
-        ("### Heading level 3 {#Test label}", vec![Token::Header(3, "Heading level 3", Some("Test label"))]),
-        ("#### Heading level 4 {#Test label}", vec![Token::Header(4, "Heading level 4", Some("Test label"))]),
-        ("##### Heading level 5 {#Test label}", vec![Token::Header(5, "Heading level 5", Some("Test label"))]),
-        ("###### Heading level 6 {#Test label}", vec![Token::Header(6, "Heading level 6", Some("Test label"))]),
-        ("####### Invalid Heading level 7 {#Test label}", vec![Token::Header(6, "Invalid Heading level 7", Some("Test label"))]), 
+        ("# Heading level 1 {#Test label}", vec![Token::Header(1, "Heading level 1".to_string(), Some("Test label".to_string()))]),
+        ("## Heading level 2 {#Test label}", vec![Token::Header(2, "Heading level 2".to_string(), Some("Test label".to_string()))]),
+        ("### Heading level 3 {#Test label}", vec![Token::Header(3, "Heading level 3".to_string(), Some("Test label".to_string()))]),
+        ("#### Heading level 4 {#Test label}", vec![Token::Header(4, "Heading level 4".to_string(), Some("Test label".to_string()))]),
+        ("##### Heading level 5 {#Test label}", vec![Token::Header(5, "Heading level 5".to_string(), Some("Test label".to_string()))]),
+        ("###### Heading level 6 {#Test label}", vec![Token::Header(6, "Heading level 6".to_string(), Some("Test label".to_string()))]),
+        ("####### Invalid Heading level 7 {#Test label}", vec![Token::Header(6, "Invalid Heading level 7".to_string(), Some("Test label".to_string()))]), 
     ]);
     tests.extend(vec![
-        ("I just love **bold text**.", vec![Token::Plaintext("I just love ".to_string()), Token::Bold("bold text"), Token::Plaintext(".".to_string())]),
-        ("I just love __bold text__.", vec![Token::Plaintext("I just love ".to_string()), Token::Bold("bold text"), Token::Plaintext(".".to_string())]),
-        ("I just love *_bold text*_.", vec![Token::Plaintext("I just love ".to_string()), Token::Bold("bold text"), Token::Plaintext(".".to_string())]),
+        ("I just love **bold text**.", vec![Token::Plaintext("I just love ".to_string()), Token::Bold("bold text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just love __bold text__.", vec![Token::Plaintext("I just love ".to_string()), Token::Bold("bold text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just love *_bold text*_.", vec![Token::Plaintext("I just love ".to_string()), Token::Bold("bold text".to_string()), Token::Plaintext(".".to_string())]),
     ]);
     tests.extend(vec![
-        ("I just love *italic text*.", vec![Token::Plaintext("I just love ".to_string()), Token::Italic("italic text"), Token::Plaintext(".".to_string())]),
-        ("I just love _italic text_.", vec![Token::Plaintext("I just love ".to_string()), Token::Italic("italic text"), Token::Plaintext(".".to_string())]),
-        ("I just love *italic text_.", vec![Token::Plaintext("I just love ".to_string()), Token::Italic("italic text"), Token::Plaintext(".".to_string())]),
-        ("I just\n love *italic text_.", vec![Token::Plaintext("I just".to_string()), Token::Newline, Token::Plaintext(" love ".to_string()), Token::Italic("italic text"), Token::Plaintext(".".to_string())]),
+        ("I just love *italic text*.", vec![Token::Plaintext("I just love ".to_string()), Token::Italic("italic text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just love _italic text_.", vec![Token::Plaintext("I just love ".to_string()), Token::Italic("italic text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just love *italic text_.", vec![Token::Plaintext("I just love ".to_string()), Token::Italic("italic text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just\n love *italic text_.", vec![Token::Plaintext("I just".to_string()), Token::Newline, Token::Plaintext(" love ".to_string()), Token::Italic("italic text".to_string()), Token::Plaintext(".".to_string())]),
     ]);
     tests.extend(vec![
-        ("I just love ***bold italic text***.", vec![Token::Plaintext("I just love ".to_string()), Token::BoldItalic("bold italic text"), Token::Plaintext(".".to_string())]),
-        ("I just love ___bold italic text___.", vec![Token::Plaintext("I just love ".to_string()), Token::BoldItalic("bold italic text"), Token::Plaintext(".".to_string())]),
-        ("I just love _*_bold italic text*_*.", vec![Token::Plaintext("I just love ".to_string()), Token::BoldItalic("bold italic text"), Token::Plaintext(".".to_string())]),
+        ("I just love ***bold italic text***.", vec![Token::Plaintext("I just love ".to_string()), Token::BoldItalic("bold italic text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just love ___bold italic text___.", vec![Token::Plaintext("I just love ".to_string()), Token::BoldItalic("bold italic text".to_string()), Token::Plaintext(".".to_string())]),
+        ("I just love _*_bold italic text*_*.", vec![Token::Plaintext("I just love ".to_string()), Token::BoldItalic("bold italic text".to_string()), Token::Plaintext(".".to_string())]),
     ]);
     tests.extend(vec![
-        ("* unodered list\n", vec![Token::UnorderedListEntry("unodered list")]),
-        ("* unodered list\n* with two\n", vec![Token::UnorderedListEntry("unodered list"), Token::UnorderedListEntry("with two")]),
-        ("* unodered list\n* with two\n* with three\n", vec![Token::UnorderedListEntry("unodered list"), Token::UnorderedListEntry("with two"), Token::UnorderedListEntry("with three")]),
+        ("* unodered list\n", vec![Token::UnorderedListEntry("unodered list".to_string())]),
+        ("* unodered list\n* with two\n", vec![Token::UnorderedListEntry("unodered list".to_string()), Token::UnorderedListEntry("with two".to_string())]),
+        ("* unodered list\n* with two\n* with three\n", vec![Token::UnorderedListEntry("unodered list".to_string()), Token::UnorderedListEntry("with two".to_string()), Token::UnorderedListEntry("with three".to_string())]),
     ]);
     tests.extend(vec![
-        ("Some text _with italics_ in the same paragraph", vec![Token::Plaintext("Some text ".to_string()), Token::Italic("with italics"), Token::Plaintext(" in the same paragraph".to_string())]),
+        ("Some text _with italics_ in the same paragraph", vec![Token::Plaintext("Some text ".to_string()), Token::Italic("with italics".to_string()), Token::Plaintext(" in the same paragraph".to_string())]),
         ("Text attributes _italic_, \n**bold**, `monospace`. Some implementations may use *single-asterisks* for italic text.", 
         vec![
             Token::Plaintext("Text attributes ".to_string()), 
-            Token::Italic("italic"), 
+            Token::Italic("italic".to_string()), 
             Token::Plaintext(", ".to_string()),
             Token::Newline,
-            Token::Bold("bold"), 
+            Token::Bold("bold".to_string()), 
             Token::Plaintext(", ".to_string()), 
-            Token::Code("monospace"),
+            Token::Code("monospace".to_string()),
             Token::Plaintext(". Some implementations may use ".to_string()),
-            Token::Italic("single-asterisks"), 
+            Token::Italic("single-asterisks".to_string()), 
             Token::Plaintext(" for italic text.".to_string()),
         ])
     ]);
     tests.extend(vec![
-        ("![alt](https://example.com/foo.jpeg)", vec![Token::Image("https://example.com/foo.jpeg", Some("alt"))]),
-        ("![alt]()", vec![Token::Image("", Some("alt"))]),
+        ("![alt](https://example.com/foo.jpeg)", vec![Token::Image("https://example.com/foo.jpeg".to_string(), Some("alt".to_string()))]),
+        ("![alt]()", vec![Token::Image("".to_string(), Some("alt".to_string()))]),
         ("Some test text [^1]", vec![Token::Plaintext("Some test text [^1]".to_string())]),
-        ("[^1]: First footnote", vec![Token::Footnote("1", "First footnote")]),
-        ("[^HUGE]: Big footnote", vec![Token::Footnote("HUGE", "Big footnote")]),
+        ("[^1]: First footnote", vec![Token::Footnote("1".to_string(), "First footnote".to_string())]),
+        ("[^HUGE]: Big footnote", vec![Token::Footnote("HUGE".to_string(), "Big footnote".to_string())]),
         ("[^BORK ED]: Big footnote", vec![Token::Plaintext("[^BORK ED]: Big footnote".to_string())]),
 
     ]);
@@ -72,12 +72,12 @@ fn test_lex() {
         ("---", vec![Token::HorizontalRule]),
         ("-----", vec![Token::HorizontalRule]),
         ("--", vec![Token::Plaintext("--".to_string())]),
-        ("- [ ] Unchecked box", vec![Token::TaskListItem(TaskBox::Unchecked, "Unchecked box")]),
-        ("+ [ ] Unchecked box", vec![Token::TaskListItem(TaskBox::Unchecked, "Unchecked box")]),
-        ("- [x] Checked box", vec![Token::TaskListItem(TaskBox::Checked, "Checked box")]),
-        ("- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "Also a checked box")]),
-        ("- [X]Not a checked box", vec![Token::UnorderedListEntry("[X]Not a checked box")]),
-        ("- [X] A checked box\n- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "A checked box"), Token::Newline, Token::TaskListItem(TaskBox::Checked, "Also a checked box")]),
+        ("- [ ] Unchecked box", vec![Token::TaskListItem(TaskBox::Unchecked, "Unchecked box".to_string())]),
+        ("+ [ ] Unchecked box", vec![Token::TaskListItem(TaskBox::Unchecked, "Unchecked box".to_string())]),
+        ("- [x] Checked box", vec![Token::TaskListItem(TaskBox::Checked, "Checked box".to_string())]),
+        ("- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "Also a checked box".to_string())]),
+        ("- [X]Not a checked box", vec![Token::UnorderedListEntry("[X]Not a checked box".to_string())]),
+        ("- [X] A checked box\n- [X] Also a checked box", vec![Token::TaskListItem(TaskBox::Checked, "A checked box".to_string()), Token::Newline, Token::TaskListItem(TaskBox::Checked, "Also a checked box".to_string())]),
     ]);
     for test in tests.iter(){
         let tokens = lex(test.0);
@@ -113,9 +113,9 @@ fn test_lex_plaintext() {
 fn test_blockquote_lex() {
     let mut tests = Vec::new();
     tests.extend(vec![
-        ("> ", vec![Token::BlockQuote(1, "")]),
-        ("> \n>> text", vec![Token::BlockQuote(1, ""), Token::BlockQuote(2, "text")]),
-        ("> text\n> \n>> more text", vec![Token::BlockQuote(1, "text") ,Token::BlockQuote(1, ""), Token::BlockQuote(2, "more text")]),
+        ("> ", vec![Token::BlockQuote(1, "".to_string())]),
+        ("> \n>> text", vec![Token::BlockQuote(1, "".to_string()), Token::BlockQuote(2, "text".to_string())]),
+        ("> text\n> \n>> more text", vec![Token::BlockQuote(1, "text".to_string()) ,Token::BlockQuote(1, "".to_string()), Token::BlockQuote(2, "more text".to_string())]),
 
     ]);
 
@@ -129,11 +129,11 @@ fn test_blockquote_lex() {
 fn test_footnote_lex() {
     let mut tests = Vec::new();
     tests.extend(vec![
-        ("[^1]: Footnote #1", vec![Token::Footnote("1", "Footnote #1")]),
-        ("[^1]: Footnote #1\n  with a second line", vec![Token::Footnote("1", "Footnote #1\n  with a second line")]),
-        ("[^1]: Footnote #1\n\twith a second line", vec![Token::Footnote("1", "Footnote #1\n\twith a second line")]),
-        ("[^1]: Footnote #1\n    with a second line", vec![Token::Footnote("1", "Footnote #1\n    with a second line")]),
-        ("[^1]: Footnote #1\n    with a second line\n\tand a third line", vec![Token::Footnote("1", "Footnote #1\n    with a second line\n\tand a third line")]),
+        ("[^1]: Footnote #1", vec![Token::Footnote("1".to_string(), "Footnote #1".to_string())]),
+        ("[^1]: Footnote #1\n  with a second line", vec![Token::Footnote("1".to_string(), "Footnote #1\n  with a second line".to_string())]),
+        ("[^1]: Footnote #1\n\twith a second line", vec![Token::Footnote("1".to_string(), "Footnote #1\n\twith a second line".to_string())]),
+        ("[^1]: Footnote #1\n    with a second line", vec![Token::Footnote("1".to_string(), "Footnote #1\n    with a second line".to_string())]),
+        ("[^1]: Footnote #1\n    with a second line\n\tand a third line", vec![Token::Footnote("1".to_string(), "Footnote #1\n    with a second line\n\tand a third line".to_string())]),
     ]);
 
     for test in tests.iter(){
@@ -147,9 +147,9 @@ fn test_link_lex(){
     let mut tests = Vec::new();
     tests.extend(vec![
         ("another (See [Sewer Shark](https://en.wikipedia.org/wiki/Sewer_Shark)). Video", 
-        vec![Token::Plaintext("another (See ".to_string()), Token::Link("https://en.wikipedia.org/wiki/Sewer_Shark", Some("Sewer Shark"), None), Token::Plaintext("). Video".to_string())]),
+        vec![Token::Plaintext("another (See ".to_string()), Token::Link("https://en.wikipedia.org/wiki/Sewer_Shark".to_string(), Some("Sewer Shark".to_string()), None), Token::Plaintext("). Video".to_string())]),
         ("r [Distant Worlds](https://www.youtube.com/watch?v=yd3KYOei8o4) a",
-        vec![Token::Plaintext("r ".to_string()), Token::Link("https://www.youtube.com/watch?v=yd3KYOei8o4", Some("Distant Worlds"), None), Token::Plaintext(" a".to_string())])
+        vec![Token::Plaintext("r ".to_string()), Token::Link("https://www.youtube.com/watch?v=yd3KYOei8o4".to_string(), Some("Distant Worlds".to_string()), None), Token::Plaintext(" a".to_string())])
     ]);
 
     for test in tests.iter(){


### PR DESCRIPTION
Commonmark support will need Strings in at least a few places and this will help speed development on that front
🤞 we can move back to &strs after commonmark support is in place