### PR TITLE
Enable blankline logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,9 +242,9 @@ pub fn parse(tokens: &[Token]) -> String {
                             count+=1;
                         } else {s.push_str(tok)}
                     }
-                    html.push_str(&s.trim_end_matches('\n'));
+                    html.push_str(&s.trim_end());
                 } else {
-                    html.push_str(sanitize_display_text(t.trim_start_matches('\n')).trim_end_matches('\n'))
+                    html.push_str(sanitize_display_text(t.trim_start_matches('\n')).trim_end())
                 }
             },
             Token::Header(l, t, lbl) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,22 @@ pub fn parse(tokens: &[Token]) -> String {
         // Add content
         match token {
             Token::Plaintext(t) => {
+                let mut t: String = t.to_string();
                 if t.trim().is_empty() {continue}
                 
+                // Trim trailing whitespace after a \n
+                match t.rfind('\n') {
+                    None => {},
+                    Some(n_index) => {
+                        let (before, after) = t.split_at(n_index);
+                        if after.chars().all(|c| c.is_whitespace()) {
+                            println!("{:?},{:?}", before, after);
+                            println!("{:?}", t.trim_end_matches(after));
+                            t = t.trim_end_matches(after).to_string();
+                        } 
+                    }
+                }
+
                 // Handle references
                 if t.contains("[^") && t.contains("]") {
                     let plaintext_tokens = t.split("[^");
@@ -242,9 +256,9 @@ pub fn parse(tokens: &[Token]) -> String {
                             count+=1;
                         } else {s.push_str(tok)}
                     }
-                    html.push_str(&s.trim_end());
+                    html.push_str(&s);
                 } else {
-                    html.push_str(sanitize_display_text(t.trim_start_matches('\n')).trim_end())
+                    html.push_str(&sanitize_display_text(t.trim_start_matches('\n')))
                 }
             },
             Token::Header(l, t, lbl) => {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,7 @@ mod commonmark {
 	mod atx_headings;
 	mod autolinks;
 	// mod backslash_escapes;
-	// mod blank_lines;
+	mod blank_lines;
 	// mod block_quotes;
 	// mod code_spans;
 	// mod emphasis_and_strong_emphasis;


### PR DESCRIPTION
Simple PR to conform to commonmark blankline logic. One new test case enabled and a little trim logic change on plaintext tokens.