### PR TITLE
Extra utf test case

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,7 +10,13 @@ impl <'a> Iterator for MiniIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         for i in 1..=4 {
             if self.the_str.is_char_boundary(self.index+i) {
+                println!("0 >> {:?}", self.the_str.get(self.index..self.index+0));
+                println!("1 >> {:?}", self.the_str.get(self.index..self.index+1));
+                println!("2 >> {:?}", self.the_str.get(self.index..self.index+2));
+                println!("3 >> {:?}", self.the_str.get(self.index..self.index+3));
+                println!("4 >> {:?}", self.the_str.get(self.index..self.index+4));
                 let ret = self.the_str.get(self.index..self.index+i);
+                println!("ret: {:?}, i: {:?}", ret, i);
                 self.index += i;
                 return ret
             }

--- a/tests/iter_tests/all.rs
+++ b/tests/iter_tests/all.rs
@@ -19,6 +19,14 @@ fn peek_does_not_advance_utf(){
 }
 
 #[test]
+fn modern_standard_arabic_test(){
+    let some_text = "الْﺦﷺأَ"; // لْ is a weird character. 2 bytes are valid for the base and two more add the little circle on top.
+    let mut some_text_iter = MiniIter::new(&some_text);
+    assert_eq!(Some("الْﺦﷺأَ"), some_text_iter.consume_line_ahead());
+    assert_eq!(None, some_text_iter.next());
+}
+
+#[test]
 fn consume_until_end_consumes_full_string() {
     let some_text = "this is some plaintext";
     let mut some_text_iter = MiniIter::new(&some_text);


### PR DESCRIPTION
Add test case to ensure that composite utf characters at least parse in a line correctly. `لْ` is a strange character which is 4 bytes with the little circle on top but the first two bytes are a valid `ل`. Given that this is not a control character it should suffice to ensure that it doesn't break reading a full line at a time.